### PR TITLE
Support to different locales on internal Intl.NumberFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Optional, max value permitted.
 `currency`
 Optional, currency you want to use as mask. Default is BRL.
 
+`locale`
+Optional, locale you want to format currency. Default is `pt-BR`.
+
 `hideSymbol`
 Optional, boolean to control the currency symbol display.
 

--- a/src/functions/format.ts
+++ b/src/functions/format.ts
@@ -1,7 +1,7 @@
 const SYMBOL_LENGTH = 3;
 
-export const formatCurrency = (value: number, currencyType = 'BRL', hideSymbol = false) => {
-  const formatter = new Intl.NumberFormat('pt-BR', {
+export const formatCurrency = (locale: string = 'pt-BR', value: number, currencyType = 'BRL', hideSymbol = false) => {
+  const formatter = new Intl.NumberFormat(locale, {
     style: 'currency',
     currency: currencyType,
     currencyDisplay: 'symbol',

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -30,6 +30,7 @@ export const normalizeValue = (number: string | number) => {
 };
 
 export const maskValues = (
+  locale: string,
   inputFieldValue: string | number | undefined,
   currency: string,
   shouldCutSymbol: boolean,
@@ -37,7 +38,7 @@ export const maskValues = (
   if (!inputFieldValue) return [0, ''];
 
   const value = normalizeValue(inputFieldValue);
-  const maskedValue = formatCurrency(value, currency, shouldCutSymbol);
+  const maskedValue = formatCurrency(locale, value, currency, shouldCutSymbol);
 
   return [value, maskedValue];
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, ICurrencyMaskProps>(
       defaultValue,
       hideSymbol = false,
       currency = 'BRL',
+      locale = 'pt-BR',
       max,
       autoSelect,
       autoReset,
@@ -28,7 +29,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, ICurrencyMaskProps>(
     const [maskedValue, setMaskedValue] = useState<number | string>('0');
 
     const updateValues = (originalValue: string | number) => {
-      const [calculatedValue, calculatedMaskedValue] = maskValues(originalValue, currency, hideSymbol);
+      const [calculatedValue, calculatedMaskedValue] = maskValues(locale, originalValue, currency, hideSymbol);
 
       if (!max || calculatedValue <= max) {
         setMaskedValue(calculatedMaskedValue);
@@ -52,7 +53,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, ICurrencyMaskProps>(
       const [originalValue, maskedValue] = updateValues(event.target.value);
 
       if (autoReset) {
-        maskValues(0, currency, hideSymbol);
+        maskValues(locale, 0, currency, hideSymbol);
       }
 
       if (maskedValue && onBlur) {
@@ -77,7 +78,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, ICurrencyMaskProps>(
 
     useEffect(() => {
       const currentValue = value || defaultValue || undefined;
-      const [, maskedValue] = maskValues(currentValue, currency, hideSymbol);
+      const [, maskedValue] = maskValues(locale, currentValue, currency, hideSymbol);
 
       setMaskedValue(maskedValue);
     }, [currency, defaultValue, hideSymbol, value]);

--- a/src/types/CurrencyMask.ts
+++ b/src/types/CurrencyMask.ts
@@ -6,6 +6,7 @@ export interface ICurrencyMaskProps {
   value?: number | string;
   max?: number;
   currency?: string;
+  locale?: string;
   hideSymbol?: boolean;
   autoSelect?: boolean;
   autoReset?: boolean;


### PR DESCRIPTION
Hey @leoreisdias, thanks for sharing that react component works nicely.

### Description
I'm currently trying to use them on a new project but the `maskValues` helpers have hard-coded the `locale` in the `Intl.NumberFormat` function.

### Changes
- Added a new `locale` prop to support different locales available.
- Changed logic to use `locale` value in `maskValues` and `formatCurrency` helpers.

Let me know what you think. Happy to contribute 🎉 