### PR TITLE
Running onChenge even when input is empty

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -34,7 +34,7 @@ export const maskValues = (
   inputFieldValue: string | number | undefined,
   currency: string,
   shouldCutSymbol: boolean,
-) => {
+): [number, string] => {
   if (!inputFieldValue) return [0, ''];
 
   const value = normalizeValue(inputFieldValue);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,10 +43,8 @@ export const CurrencyInput = forwardRef<HTMLInputElement, ICurrencyMaskProps>(
       event.preventDefault();
 
       const [originalValue, maskedValue] = updateValues(event.target.value);
-
-      if (maskedValue) {
-        onChangeValue(event, originalValue, maskedValue);
-      }
+      
+      onChangeValue(event, originalValue, maskedValue);
     };
 
     const handleBlur = (event: FocusEvent<HTMLInputElement, Element>) => {


### PR DESCRIPTION
Closes #4 

### 📝 Description
Fixing issue with 'onChange' callback not being executed when input is completely cleared


### ⛳️ Current behavior (updates)
When the input is cleared by a user action the 'onChange' callback passed to the component is not executed

### 🚀 New behavior
The 'onChange' callback is executed whenever the input's native 'onChange' event fires

### 💣 Is this a breaking change (Yes/No):
No