### PR TITLE
fix: add support for negative values

### DIFF
--- a/src/functions/format.ts
+++ b/src/functions/format.ts
@@ -1,5 +1,3 @@
-const SYMBOL_LENGTH = 3;
-
 export const formatCurrency = (locale: string = 'pt-BR', value: number, currencyType = 'BRL', hideSymbol = false) => {
   const formatter = new Intl.NumberFormat(locale, {
     style: 'currency',
@@ -8,7 +6,22 @@ export const formatCurrency = (locale: string = 'pt-BR', value: number, currency
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
-  const formattedValue = formatter.format(value);
+  let formattedValue = formatter.format(value);
 
-  return formattedValue.slice(hideSymbol ? SYMBOL_LENGTH : 0);
+  if (hideSymbol) {
+    const symbolParts = new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: currencyType,
+      currencyDisplay: 'symbol',
+    }).formatToParts(0);
+
+    const symbolPart = symbolParts.find((x) => x.type === 'currency');
+    const symbol = symbolPart ? symbolPart.value : '';
+
+    formattedValue = formattedValue.replace(symbol, '').trim();
+    formattedValue = formattedValue.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+    formattedValue = formattedValue.replace(/^-\s*/, '-');
+  }
+
+  return formattedValue;
 };

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -7,7 +7,10 @@ export const clearNumber = (number: any) => {
   }
 
   // strips everything that is not a number (positive or negative)
-  return Number(number.toString().replace(/[^0-9-]/g, ''));
+  let str = number.toString().replace(/[^0-9-]/g, '');
+  const isNegative = str.startsWith('-');
+  str = str.replace(/-/g, '');
+  return Number((isNegative ? '-' : '') + str);
 };
 
 export const normalizeValue = (number: string | number) => {


### PR DESCRIPTION
Fixes issue #6 where negative numbers were either incorrectly parsed or formatted, leading to missing negative signs when `hideSymbol` was set, or `NaN` values when clearing values.

---
*PR created automatically by Jules for task [14526231786035783569](https://jules.google.com/task/14526231786035783569) started by @leoreisdias*